### PR TITLE
Strip mpassi of optimizations to enable GNU compilation of FullyCoupled compset

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -524,6 +524,13 @@ ifeq ($(strip $(COMP_ATM)),cam)
   endif
 endif
 
+ifeq ($(COMP_NAME),mpassi)
+  ifeq ($(strip $(COMPILER)),gnu)
+    # mpas seaice files can't compile with optimization using gnu
+    FFLAGS += -O0
+  endif
+endif
+
 ifeq ($(COMP_NAME),cam)
   # These RRTMG files take an extraordinarily long time to compile with optimization.
   # Until mods are made to read the data from files, just remove optimization from


### PR DESCRIPTION
Currently the mpas-seaice build will not succeed with optimization levels above zero. This change prevents compiler optimization when the GNU compilers are used for mpas-seaice.

NOTE: currently this only enables the build with GNU but the code does not execute correctly. The ability to build and run the FullyCoupled compset with the Intel compilers is unaffected by these changes.