### PR TITLE
Apply unoptimized GNU build flags to only one MPAS-SI file

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -526,8 +526,9 @@ endif
 
 ifeq ($(COMP_NAME),mpassi)
   ifeq ($(strip $(COMPILER)),gnu)
-    # mpas seaice files can't compile with optimization using gnu
-    FFLAGS += -O0
+    # mpas seaice files that can't compile with optimization using gnu
+    ice_shortwave.o : ice_shortwave.F90
+        $(FC) -c $(FPPFLAGS) $(INCLDIR) $(INCS) $(FREEFLAGS) $(FFLAGS) $(FFLAGS_NOOPT) $<
   endif
 endif
 


### PR DESCRIPTION
This change allows GNU suite compilers to build most of MPAS-SI with optimization except for ice_shortwave.F90. If built with optimization currently, model runs terminate execution on time step 1 due to the seaice failing a "State validation" check.