### PR TITLE
merge update/ocean3p75

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -520,6 +520,13 @@ ice_shortwave.o : ice_shortwave.F90
 endif
 endif
 
+ifeq ($(COMP_NAME),mpaso)
+  ifeq ($(strip $(COMPILER)),nvhpc)
+  # mpas ocean files need gpuflags
+    FFLAGS +=$(GPUFLAGS)
+  endif
+endif
+
 ifeq ($(COMP_NAME),cam)
   # These RRTMG files take an extraordinarily long time to compile with optimization.
   # Until mods are made to read the data from files, just remove optimization from


### PR DESCRIPTION
Merge branch update/ocean3p75

This is a collection of commits that do the following:
Defaults have been added/updated for higher (15km, 7.5km and 3.75km) resolutions.
Diagnostic output defaults have been added to better align ocean and seaice diagnostic files with month boundaries. This reduces data loss at a restart.
Ocean gpu code can be built and run. However, the gpu solution is different from the cpu solution and needs further debugging.
Ocean surface salinity forcing has been merged into one ocean code base. Ocean and seaice time managers now no longer use the ESMF library, but use esmf-emulating code E3SM provided with the code.

Components part of this PR:
ccs_config
cime
mpas-ocean 
mpas-seaice
mpas-framework

Here specifically, code is added to Tools/Makefile to get gpuflags to the mpas-ocean.