### PR TITLE
fix ocean gpu compilation

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -523,7 +523,7 @@ endif
 ifeq ($(COMP_NAME),mpaso)
   ifeq ($(strip $(COMPILER)),nvhpc)
   # mpas ocean files need gpuflags
-    FFLAGS +=$(GPUFLAGS)
+    FFLAGS +=$(OPENACC_GPU_FLAGS)
   endif
 endif
 


### PR DESCRIPTION
EWv2.5 changed GPUFLAGS to OPENACC_GPU_FLAGS. This file is modified to adapt to that change so that the ocean will continue to compile on gpus.

