### PR TITLE
Fixing mpas-ocean gpu compile

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -523,7 +523,7 @@ endif
 ifeq ($(COMP_NAME),mpaso)
   ifeq ($(strip $(COMPILER)),nvhpc)
   # mpas ocean files need gpuflags
-    FFLAGS +=$(GPUFLAGS)
+    FFLAGS +=$(MPASO_OPENACC_GPU_FLAGS)
   endif
 endif
 


### PR DESCRIPTION
The variable for compilation flags for mpas-ocean compilation is changed to a new variable that has ocean-specific options.

