### PR TITLE
Undo changes from PR #21 for MPAS-O on GPUs

### DIFF
--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -520,12 +520,12 @@ ice_shortwave.o : ice_shortwave.F90
 endif
 endif
 
-ifeq ($(COMP_NAME),mpaso)
-  ifeq ($(strip $(COMPILER)),nvhpc)
-  # mpas ocean files need gpuflags
-    FFLAGS +=$(OPENACC_GPU_FLAGS)
-  endif
-endif
+# ifeq ($(COMP_NAME),mpaso)
+#   ifeq ($(strip $(COMPILER)),nvhpc)
+#   # mpas ocean files need gpuflags
+#     FFLAGS +=$(OPENACC_GPU_FLAGS)
+#   endif
+# endif
 
 ifeq ($(COMP_NAME),cam)
   # These RRTMG files take an extraordinarily long time to compile with optimization.

--- a/CIME/Tools/Makefile
+++ b/CIME/Tools/Makefile
@@ -523,7 +523,7 @@ endif
 ifeq ($(COMP_NAME),mpaso)
   ifeq ($(strip $(COMPILER)),nvhpc)
   # mpas ocean files need gpuflags
-    FFLAGS +=$(MPASO_OPENACC_GPU_FLAGS)
+    FFLAGS +=$(OPENACC_GPU_FLAGS)
   endif
 endif
 


### PR DESCRIPTION
This PR comments out the section added by PR#21. There may be more changes later on that re-enable or modify the MPAS-O GPU build.